### PR TITLE
Updated MainActivity.kt to fix layout issue

### DIFF
--- a/app/src/main/java/com/example/diceroller/MainActivity.kt
+++ b/app/src/main/java/com/example/diceroller/MainActivity.kt
@@ -63,7 +63,6 @@ class MainActivity : ComponentActivity() {
 fun DiceRollerApp() {
     DiceWithButtonAndImage(modifier = Modifier
         .fillMaxSize()
-        .wrapContentSize(Alignment.Center)
     )
 }
 
@@ -78,7 +77,7 @@ fun DiceWithButtonAndImage(modifier: Modifier = Modifier) {
         5 -> R.drawable.dice_5
         else -> R.drawable.dice_6
     }
-    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(modifier = modifier.wrapContentSize(Alignment.Center), horizontalAlignment = Alignment.CenterHorizontally) {
         Image(painter = painterResource(imageResource), contentDescription = result.toString())
         
         Button(


### PR DESCRIPTION
This pull request is based off an issue that I created. It can be found here: https://github.com/google-developer-training/basic-android-kotlin-compose-training-dice-roller/issues/142

The link above will have the details on what I discovered in the codelab and the corrections I made so that the dice and the button will appear on the center of the screen. Please read it first before approving this pull request. 